### PR TITLE
add Hash2 func with uintptr as resulting type

### DIFF
--- a/hasher.go
+++ b/hasher.go
@@ -41,10 +41,7 @@ func NewSeed[K comparable](h Hasher[K]) Hasher[K] {
 
 // Hash hashes |key|.
 func (h Hasher[K]) Hash(key K) uint64 {
-	// promise to the compiler that pointer
-	// |p| does not escape the stack.
-	p := noescape(unsafe.Pointer(&key))
-	return uint64(h.hash(p, h.seed))
+	return uint64(h.Hash2(key))
 }
 
 // Hash2 hashes |key| as more flexible uintptr.

--- a/hasher.go
+++ b/hasher.go
@@ -46,3 +46,11 @@ func (h Hasher[K]) Hash(key K) uint64 {
 	p := noescape(unsafe.Pointer(&key))
 	return uint64(h.hash(p, h.seed))
 }
+
+// Hash2 hashes |key| as more flexible uintptr.
+func (h Hasher[K]) Hash2(key K) uintptr {
+	// promise to the compiler that pointer
+	// |p| does not escape the stack.
+	p := noescape(unsafe.Pointer(&key))
+	return h.hash(p, h.seed)
+}

--- a/hasher_test.go
+++ b/hasher_test.go
@@ -178,12 +178,20 @@ func testHasher[K comparable](t *testing.T, key K) {
 	assert.Equal(t, h1.Hash(key), h1.Hash(key))
 	assert.Equal(t, h2.Hash(key), h2.Hash(key))
 	assert.NotEqual(t, h1.Hash(key), h2.Hash(key))
+	assert.Equal(t, h1.Hash2(key), h1.Hash2(key))
+	assert.Equal(t, h2.Hash2(key), h2.Hash2(key))
+	assert.NotEqual(t, h1.Hash2(key), h2.Hash2(key))
 	h3, h4 := NewSeed[K](h1), NewSeed[K](h2)
 	assert.Equal(t, h3.Hash(key), h3.Hash(key))
 	assert.Equal(t, h4.Hash(key), h4.Hash(key))
 	assert.NotEqual(t, h1.Hash(key), h3.Hash(key))
 	assert.NotEqual(t, h2.Hash(key), h4.Hash(key))
 	assert.NotEqual(t, h3.Hash(key), h4.Hash(key))
+	assert.Equal(t, h3.Hash2(key), h3.Hash2(key))
+	assert.Equal(t, h4.Hash2(key), h4.Hash2(key))
+	assert.NotEqual(t, h1.Hash2(key), h3.Hash2(key))
+	assert.NotEqual(t, h2.Hash2(key), h4.Hash2(key))
+	assert.NotEqual(t, h3.Hash2(key), h4.Hash2(key))
 }
 
 func TestRefAllocs(t *testing.T) {


### PR DESCRIPTION
 The uintptr type has different sizes of different
 platforms. Therefore this type is more flexible
 and faster also on 32Bit Systems, instead of using a
 fixed sized uint64. Furthermore a uintptr can hold any array
 index, because it can hold any pointer (array of uint8).